### PR TITLE
Update job application status function added to Company Enterprise

### DIFF
--- a/NiceJobApp/src/UI/CityServiceLoginJPanel.java
+++ b/NiceJobApp/src/UI/CityServiceLoginJPanel.java
@@ -167,8 +167,8 @@ public class CityServiceLoginJPanel extends javax.swing.JPanel {
            // UniStudentJPanel studentPanel = new UniStudentJPanel(splitPane, conn);
            // splitPane.setRightComponent(studentPanel);
         }else if(username.equalsIgnoreCase(txtUsername.getText()) && password.equalsIgnoreCase(new String(passwordField.getPassword())) && choice.equalsIgnoreCase("advisor")){
-            UniCareerAdvisorJPanel advisorPanel = new UniCareerAdvisorJPanel(splitPane, conn);
-            splitPane.setRightComponent(advisorPanel);
+//            UniCareerAdvisorJPanel advisorPanel = new UniCareerAdvisorJPanel(splitPane, conn);
+//            splitPane.setRightComponent(advisorPanel);
         }else if(username.equalsIgnoreCase(txtUsername.getText()) && password.equalsIgnoreCase(new String(passwordField.getPassword())) && choice.equalsIgnoreCase("examCell")){
             UniExamCellJPanel examCellPanel = new UniExamCellJPanel(splitPane, conn);
             splitPane.setRightComponent(examCellPanel);

--- a/NiceJobApp/src/UI/CompanyDepartmentJPanel.form
+++ b/NiceJobApp/src/UI/CompanyDepartmentJPanel.form
@@ -1157,11 +1157,12 @@
                           <Font name="Trebuchet MS" size="15" style="0"/>
                         </Property>
                         <Property name="model" type="javax.swing.ComboBoxModel" editor="org.netbeans.modules.form.editors2.ComboBoxModelEditor">
-                          <StringArray count="4">
+                          <StringArray count="5">
                             <StringItem index="0" value="Applied"/>
                             <StringItem index="1" value="Interview Scheduled"/>
                             <StringItem index="2" value="Accepted"/>
-                            <StringItem index="3" value="Rejected"/>
+                            <StringItem index="3" value="On-Hold"/>
+                            <StringItem index="4" value="Rejected"/>
                           </StringArray>
                         </Property>
                       </Properties>

--- a/NiceJobApp/src/UI/UniStudentJPanel.form
+++ b/NiceJobApp/src/UI/UniStudentJPanel.form
@@ -1617,8 +1617,10 @@
                         </Component>
                         <Component class="button.Button" name="btnWithdraw">
                           <Properties>
+                            <Property name="foreground" type="java.awt.Color" editor="org.netbeans.beaninfo.editors.ColorEditor">
+                              <Color blue="0" green="0" red="0" type="rgb"/>
+                            </Property>
                             <Property name="text" type="java.lang.String" value="Withdraw Application"/>
-                            <Property name="enabled" type="boolean" value="false"/>
                             <Property name="font" type="java.awt.Font" editor="org.netbeans.beaninfo.editors.FontEditor">
                               <Font name="Trebuchet MS" size="18" style="1"/>
                             </Property>

--- a/NiceJobApp/src/UI/UniStudentJPanel.java
+++ b/NiceJobApp/src/UI/UniStudentJPanel.java
@@ -61,10 +61,10 @@ public class UniStudentJPanel extends javax.swing.JPanel {
         
         if(student.getJdWatchAccess()){
             studentTabbedPane.setEnabledAt(1, true);
-            studentTabbedPane.setEnabledAt(2, true);
+            btnWithdraw.setEnabled(true);
         }else{
             studentTabbedPane.setEnabledAt(1, false);
-            studentTabbedPane.setEnabledAt(2, false);
+            btnWithdraw.setEnabled(false);
         }
         
         populateAllFields(student);
@@ -953,8 +953,8 @@ public class UniStudentJPanel extends javax.swing.JPanel {
             }
         });
 
+        btnWithdraw.setForeground(new java.awt.Color(0, 0, 0));
         btnWithdraw.setText("Withdraw Application");
-        btnWithdraw.setEnabled(false);
         btnWithdraw.setFont(new java.awt.Font("Trebuchet MS", 1, 18)); // NOI18N
         btnWithdraw.addActionListener(new java.awt.event.ActionListener() {
             public void actionPerformed(java.awt.event.ActionEvent evt) {
@@ -1787,7 +1787,12 @@ public class UniStudentJPanel extends javax.swing.JPanel {
         }else{
             txtStatus.setText("");
         }
-        btnWithdraw.setEnabled(true);
+        if(student.getJdWatchAccess()){
+            btnWithdraw.setEnabled(true);
+        }else{
+            btnWithdraw.setEnabled(false);
+        }
+        
     }
     
     public void clearAllFieldsMyApp(){

--- a/NiceJobApp/src/model/JobAppointmentsDir.java
+++ b/NiceJobApp/src/model/JobAppointmentsDir.java
@@ -99,4 +99,10 @@ public class JobAppointmentsDir {
         }
         return newJobApps;
     }
+    
+    public ArrayList<JobAppointments> updateJobAppointment(JobAppointments oldJobAppointment,JobAppointments updateJobAppointment){
+        Integer ind = jobAppointmentsList.indexOf(oldJobAppointment);
+        jobAppointmentsList.set(ind, updateJobAppointment);
+        return jobAppointmentsList;
+    }
 }


### PR DESCRIPTION
The roles under the company's recruitment organization can now update job application status, which are also concurrently reflected in the database. Once the student/candidate is selected, the student/candidate no longer has access to the job watch portal and can only view their past job applications. The candidate can also no longer withdraw their previously filled applications. Other options in application status include rejected, interviews, on-hold which guarantee the student access to the job portal since the student can search for multiple jobs at the same time even after giving interviews or being on hold or after being rejected.